### PR TITLE
Fix pypi-server startup command when use_htaccess_file is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Role Variables
   }}/pypi.pid`.'
 * `htaccess_dir`: 'The location of the generated `.htaccess` file. Default: `{{
   pypi_home_dir }}`.'
-* `use_htaccess_file`: 'A boolean value that determines whether to use
-  username/password authentication for uploads to the pypi-server. Default:
-  `true`.'
+* `enable_anonymous_auth`: 'A boolean value that determines whether to use
+  username/password authentication for uploads to the pypi-server. Note:
+  Enabling this is not recommended as it will allow anyone to upload artifacts
+  to pypi. Default: `false`.'
 * `htaccess_username`: 'Username to use when authenticating to the pypi-server
-  (only used when `use_htaccess_file is true`). Default: `none`.'
+  (only used when `enable_anonymous_auth is false`). Default: `test`.'
 * `htaccess_password`: 'Password to use when authenticating to the pypi-server
-  (only used when `use_htaccess_file is true`). Default: `none`.'
+  (only used when `enable_anonymous_auth is false`). Default: `test`.'
 * `python_packages`: 'A list of pypi-server dependency python packages installed
   via `pip`.'
                   Default:
@@ -55,7 +56,7 @@ passed in as parameters) is always nice for users too:
 ```yaml
     - hosts: servers
       roles:
-         - { role: comcast.pypi }
+         - role: comcast.pypi
 ```
 
 Testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,6 @@ pypi_server_pid_file: '{{ pypi_work_dir }}/pypi.pid'
 pypi_requirements_template: 'templates/pypi-server-requirements.txt.j2'
 
 htaccess_dir: '{{ pypi_home_dir }}'
-use_htaccess_file: true
-htaccess_username: ''
-htaccess_password: ''
+enable_anonymous_auth: false
+htaccess_username: 'test'
+htaccess_password: 'test'

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,6 +1,4 @@
 ---
 - hosts: all
   roles:
-    - role: ansible-pypi
-      htaccess_username: 'test'
-      htaccess_password: 'test'
+    - role: ansible-role-pypi

--- a/templates/pypi-server.service.j2
+++ b/templates/pypi-server.service.j2
@@ -9,10 +9,10 @@ PIDFile={{ pypi_server_pid_file }}
 User={{ pypi_user }}
 Group={{ pypi_group }}
 
-{% if use_htaccess_file %}
-ExecStart=/usr/bin/pypi-server -p {{ pypi_server_port }} -a update --log-file {{ pypi_log_file }} -P {{ htaccess_dir }}/.htaccess {{ pypi_packages_directory }}
-{% else %}
+{% if enable_anonymous_auth %}
 ExecStart=/usr/bin/pypi-server -p {{ pypi_server_port }} -a . --log-file {{ pypi_log_file }} -P . {{ pypi_packages_directory }}
+{% else %}
+ExecStart=/usr/bin/pypi-server -p {{ pypi_server_port }} -a update --log-file {{ pypi_log_file }} -P {{ htaccess_dir }}/.htaccess {{ pypi_packages_directory }}
 {% endif %}
 ExecStop=/bin/kill -TERM $MAINPID
 ExecReload=/bin/kill -HUP $MAINPID

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -13,7 +13,7 @@ group = defaults['pypi_group']
 pypi_packages_dir = defaults['pypi_home_dir'] + '/packages'
 pypi_port = defaults['pypi_server_port']
 pypi_log_file = defaults['pypi_log_file']
-use_htaccess_file = defaults['use_htaccess_file']
+enable_anonymous_auth = defaults['enable_anonymous_auth']
 htaccess_dir = defaults['pypi_home_dir']
 
 
@@ -47,7 +47,7 @@ def test_pypi_service(Service):
 
 
 def test_htaccess_file(File):
-    if use_htaccess_file:
+    if not enable_anonymous_auth:
         htaccess = File(htaccess_dir + '/.htaccess')
         assert htaccess.exists
         assert htaccess.is_file


### PR DESCRIPTION
From the pypi-server help documentation for the -a option:

```
To drop all authentications, use:
-P .  -a .
Note that when uploads are not protected, the `register` command
is not necessary, but `~/.pypirc` still need username and password fields,
even if bogus.
By default, only 'update' is password-protected.
``` 