### PR TITLE
Allow pypi-server authenticate option override

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Role Variables
   }}/pypi.pid`.'
 * `pypi_requirements_template`: 'Template listing the required packages for
   the pypi-server. Default: `templates/pypi-server-requirements.txt.j2`.'
+* `pypi_server_authenticate`: Comma-separated list of actions to authenticate
+  a client, ex.: `download,list,update`. Default: `update`.
 * `htaccess_dir`: 'The location of the generated `.htaccess` file. Default: `{{
   pypi_home_dir }}`.'
 * `enable_anonymous_auth`: 'A boolean value that determines whether to use

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ pypi_work_dir: '{{ pypi_home_dir }}'
 pypi_packages_directory: '{{ pypi_work_dir }}/packages'
 pypi_log_file: '{{ pypi_work_dir }}/pypi-server.log'
 pypi_init_script_dir: '/etc/init.d'
+pypi_server_authenticate: 'update'
 pypi_server_pid_file: '{{ pypi_work_dir }}/pypi.pid'
 pypi_requirements_template: 'templates/pypi-server-requirements.txt.j2'
 

--- a/templates/pypi-server.service.j2
+++ b/templates/pypi-server.service.j2
@@ -12,7 +12,7 @@ Group={{ pypi_group }}
 {% if enable_anonymous_auth %}
 ExecStart={{ pypi_server_bin }} -p {{ pypi_server_port }} -a . --log-file {{ pypi_log_file }} -P . {{ pypi_packages_directory }}
 {% else %}
-ExecStart={{ pypi_server_bin }} -p {{ pypi_server_port }} -a update --log-file {{ pypi_log_file }} -P {{ htaccess_dir }}/.htaccess {{ pypi_packages_directory }}
+ExecStart={{ pypi_server_bin }} -p {{ pypi_server_port }} -a {{ pypi_server_authenticate }} --log-file {{ pypi_log_file }} -P {{ htaccess_dir }}/.htaccess {{ pypi_packages_directory }}
 {% endif %}
 ExecStop=/bin/kill -TERM $MAINPID
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
In this PR we would like allow the pypi-server authenticate option override. It can be useful to make the pypi-server fully private for example.